### PR TITLE
removing --acl public-read for s3

### DIFF
--- a/ansible/playbooks/apps/aem-stack-manager/main.yaml
+++ b/ansible/playbooks/apps/aem-stack-manager/main.yaml
@@ -5,20 +5,19 @@
   connection: local
 
   tasks:
-
     - name: Ensure data bucket exists
       s3_bucket:
         region: "{{ aws.region }}"
         name: "{{ s3.data_bucket_name }}"
         state: present
       tags:
-      - create
+        - create
 
     - name: Upload CloudFormation Templates to S3
       command: >
-              aws s3 sync ../../../../cloudformation/apps/aem-stack-manager
-                  s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
-                  --include "*.yaml" --acl public-read
+        aws s3 sync ../../../../cloudformation/apps/aem-stack-manager
+            s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
+            --include "*.yaml"
       tags:
         - create
 
@@ -32,9 +31,9 @@
 
     - name: Upload SSM Documents CloudFormation Template to S3
       command: >
-              aws s3 sync ../../../../stage/
-                  s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
-                  --include "ssm-commands.yaml" --acl public-read
+        aws s3 sync ../../../../stage/
+            s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
+            --include "ssm-commands.yaml"
       tags:
         - create
 
@@ -58,8 +57,7 @@
       register: main_stack_info
       tags:
         - create
-      when:
-        permission_type == "b"
+      when: permission_type == "b"
 
     - cloudformation_facts:
         stack_name: "{{ main_stack_info.stack_resources[2].physical_resource_id.split('/')[1] }}"
@@ -68,8 +66,7 @@
       register: stack_manager_stack_info
       tags:
         - create
-      when:
-        permission_type == "b"
+      when: permission_type == "b"
 
     - name: Create Stack Manager configuration
       stack_manager_config:
@@ -86,8 +83,7 @@
         state: present
       tags:
         - create
-      when:
-        permission_type == "b"
+      when: permission_type == "b"
 
     - name: Create AEM Stack Manager Main Resources Stack with permission type c
       cloudformation:
@@ -113,8 +109,7 @@
       register: main_stack_info
       tags:
         - create
-      when:
-        permission_type == "c"
+      when: permission_type == "c"
 
     - cloudformation_facts:
         stack_name: "{{ main_stack_info.stack_resources[2].physical_resource_id.split('/')[1] }}"
@@ -123,8 +118,7 @@
       register: stack_manager_stack_info
       tags:
         - create
-      when:
-        permission_type == "c"
+      when: permission_type == "c"
 
     - name: Create Stack Manager configuration
       stack_manager_config:
@@ -141,9 +135,8 @@
         state: present
       tags:
         - create
-      when:
-        permission_type == "c"
-        
+      when: permission_type == "c"
+
     - name: Check if a Stack Exists
       command: >
         aws cloudformation describe-stacks --stack-name "{{ stack_prefix }}-{{ main.stack_name }}"
@@ -156,8 +149,7 @@
     - name: Report Stack Problem
       debug:
         msg: Stack "{{ stack_prefix }}-{{ main.stack_name }}" does not exist or some other errors occured
-      when:
-        "stack_query.rc != 0"
+      when: "stack_query.rc != 0"
       tags:
         - delete
 
@@ -166,14 +158,13 @@
         stack_name: "{{ stack_prefix }}-{{ main.stack_name }}"
         region: "{{ aws.region }}"
         state: absent
-      when:
-        "stack_query.rc == 0"
+      when: "stack_query.rc == 0"
       tags:
-      - delete
+        - delete
 
     - name: Delete All Stack Data
       command: >
-              aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"/"{{ stack_manager.s3_prefix }}"
-               --recursive --region "{{ aws.region }}"
+        aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"/"{{ stack_manager.s3_prefix }}"
+         --recursive --region "{{ aws.region }}"
       tags:
-      - delete
+        - delete

--- a/ansible/playbooks/apps/aem/consolidated/prerequisites.yaml
+++ b/ansible/playbooks/apps/aem/consolidated/prerequisites.yaml
@@ -1,25 +1,23 @@
 ---
-
 - name: AEM Consolidated Prerequisite Resources Creation and Deletion Tasks
   hosts: all
   gather_facts: no
   connection: local
 
   tasks:
-
     - name: Ensure data bucket exists
       s3_bucket:
         region: "{{ aws.region }}"
         name: "{{ s3.data_bucket_name }}"
         state: present
       tags:
-      - create
+        - create
 
     - name: Upload CloudFormation Templates to S3
       command: >
-              aws s3 sync ../../../../../cloudformation/apps/aem/consolidated
-                  s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
-                  --include "*.yaml" --acl public-read
+        aws s3 sync ../../../../../cloudformation/apps/aem/consolidated
+            s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
+            --include "*.yaml"
       tags:
         - create
 
@@ -37,9 +35,8 @@
           AuthorPublishDispatcherSecurityGroupInboundCidrIpParameter: "{{ security_groups.author_publish_dispatcher.inbound_cidr_ip }}"
           SecureShellInboundCidrIpParameter: "{{ security_groups.secure_shell.inbound_cidr_ip }}"
       tags:
-      - create
-      when:
-        permission_type == "b"
+        - create
+      when: permission_type == "b"
 
     - name: Create AEM App Prerequisite Resources Stack
       cloudformation:
@@ -56,9 +53,8 @@
           AuthorPublishDispatcherSecurityGroupInboundCidrIpParameter: "{{ security_groups.author_publish_dispatcher.inbound_cidr_ip }}"
           SecureShellInboundCidrIpParameter: "{{ security_groups.secure_shell.inbound_cidr_ip }}"
       tags:
-      - create
-      when:
-        permission_type == "c"
+        - create
+      when: permission_type == "c"
 
     - name: Check if a Stack Exists
       command: >
@@ -72,8 +68,7 @@
     - name: Report Stack Problem
       debug:
         msg: Stack "{{ stack_prefix }}-{{ prerequisites.stack_name }}" does not exist or some other errors occured
-      when:
-        "stack_query.rc != 0"
+      when: "stack_query.rc != 0"
       tags:
         - delete
 
@@ -82,14 +77,13 @@
         stack_name: "{{ stack_prefix }}-{{ prerequisites.stack_name }}"
         region: "{{ aws.region }}"
         state: absent
-      when:
-        "stack_query.rc == 0"
+      when: "stack_query.rc == 0"
       tags:
-      - delete
+        - delete
 
     - name: Delete All Stack Data
       command: >
-              aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"
-               --recursive --region "{{ aws.region }}"
+        aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"
+         --recursive --region "{{ aws.region }}"
       tags:
-      - delete
+        - delete

--- a/ansible/playbooks/apps/aem/full-set/main.yaml
+++ b/ansible/playbooks/apps/aem/full-set/main.yaml
@@ -7,9 +7,9 @@
   tasks:
     - name: Upload CloudFormation Templates to S3
       command: >
-              aws s3 sync ../../../../../cloudformation/apps/aem/full-set
-                  s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
-                  --include "*.yaml" --acl public-read
+        aws s3 sync ../../../../../cloudformation/apps/aem/full-set
+            s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
+            --include "*.yaml"
       tags:
         - create
 
@@ -82,9 +82,8 @@
           PublishDispatcherDNSRecordSetNameParameter: "{{ dns_records.publish_dispatcher.record_set_name }}"
           ImageRootDevice: "{{ ami_root_device_name }}"
       tags:
-      - create
-      when:
-        permission_type == "b"
+        - create
+      when: permission_type == "b"
 
     - name: Create AEM App Main Resources Stack with permission type c
       cloudformation:
@@ -155,9 +154,8 @@
           PublishDispatcherDNSRecordSetNameParameter: "{{ dns_records.publish_dispatcher.record_set_name }}"
           ImageRootDevice: "{{ ami_root_device_name }}"
       tags:
-      - create
-      when:
-        permission_type == "c"
+        - create
+      when: permission_type == "c"
 
     - name: Check if a Stack Exists
       command: >
@@ -171,8 +169,7 @@
     - name: Report Stack Problem
       debug:
         msg: Stack "{{ stack_prefix }}-{{ main.stack_name }}" does not exist or some other errors occured
-      when:
-        "stack_query.rc != 0"
+      when: "stack_query.rc != 0"
       tags:
         - delete
 
@@ -181,16 +178,15 @@
         stack_name: "{{ stack_prefix }}-{{ main.stack_name }}"
         region: "{{ aws.region }}"
         state: absent
-      when:
-        "stack_query.rc == 0"
+      when: "stack_query.rc == 0"
       tags:
-      - delete
+        - delete
 
     - name: Delete default deployment descriptor
       s3:
-        bucket: '{{ s3.data_bucket_name }}'
-        region: '{{ aws.region }}'
-        object: '{{ stack_prefix }}/deploy-artifacts-descriptor.json'
+        bucket: "{{ s3.data_bucket_name }}"
+        region: "{{ aws.region }}"
+        object: "{{ stack_prefix }}/deploy-artifacts-descriptor.json"
         mode: delobj
       ignore_errors: True
       tags:
@@ -200,7 +196,6 @@
       delete_sdb_domain:
         domain_name: "SIMIAN_ARMY_{{ stack_prefix }}"
         region: "{{ aws.region }}"
-      when:
-        "stack_query.rc == 0"
+      when: "stack_query.rc == 0"
       tags:
-      - delete
+        - delete

--- a/ansible/playbooks/apps/aem/full-set/prerequisites.yaml
+++ b/ansible/playbooks/apps/aem/full-set/prerequisites.yaml
@@ -1,12 +1,10 @@
 ---
-
 - name: AEM Apps Prerequisite Resources Creation and Deletion Tasks
   hosts: all
   gather_facts: no
   connection: local
 
   tasks:
-
     - name: Ensure data bucket exists
       s3_bucket:
         region: "{{ aws.region }}"
@@ -17,9 +15,9 @@
 
     - name: Upload CloudFormation Templates to S3
       command: >
-              aws s3 sync ../../../../../cloudformation/apps/aem/full-set
-                  s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
-                  --include "*.yaml" --acl public-read
+        aws s3 sync ../../../../../cloudformation/apps/aem/full-set
+            s3://{{ s3.data_bucket_name }}/{{ stack_prefix }}
+            --include "*.yaml"
       tags:
         - create
 
@@ -45,8 +43,7 @@
           SSLCertificateARNParameter: "{{ certificate_manager.ssl_certificate_arn }}"
       tags:
         - create
-      when:
-        permission_type == "b"
+      when: permission_type == "b"
 
     - name: Create AEM App Prerequisite Resources Stack with Permissions Type C
       cloudformation:
@@ -78,9 +75,7 @@
           PublishInstanceProfileParameter: "{{ publish.instance_profile }}"
       tags:
         - create
-      when:
-        permission_type == "c"
-
+      when: permission_type == "c"
 
     - name: Check if a Stack Exists
       command: >
@@ -94,8 +89,7 @@
     - name: Report Stack Problem
       debug:
         msg: Stack "{{ stack_prefix }}-{{ prerequisites.stack_name }}" does not exist or some other errors occured
-      when:
-        "stack_query.rc != 0"
+      when: "stack_query.rc != 0"
       tags:
         - delete
 
@@ -104,14 +98,13 @@
         stack_name: "{{ stack_prefix }}-{{ prerequisites.stack_name }}"
         region: "{{ aws.region }}"
         state: absent
-      when:
-        "stack_query.rc == 0"
+      when: "stack_query.rc == 0"
       tags:
-      - delete
+        - delete
 
     - name: Delete All Stack Data
       command: >
-              aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"
-               --recursive --region "{{ aws.region }}"
+        aws s3 rm s3://"{{ s3.data_bucket_name }}"/"{{ stack_prefix }}"
+         --recursive --region "{{ aws.region }}"
       tags:
-      - delete
+        - delete


### PR DESCRIPTION
Hi Cliff,
I removed --acl public-read for s3 since it's now blocked.
I have tested in non-prod for AEM 6.2 successfully.
Can you please review and merge it into your release/2.2 branch and let me know so that I can update my pipeline to use your branch again?
Thanks.
Viet